### PR TITLE
Add animated grainy gradient background

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import { Inter } from "next/font/google";
 import { Analytics } from "@vercel/analytics/react";
 import { SpeedInsights } from "@vercel/speed-insights/next";
 import { metadataConfig, viewportConfig } from "@/lib/metadata";
+import GradientBackground from "@/components/GradientBackground";
 import "../styles/globals.css";
 
 const inter = Inter({ subsets: ["latin"] });
@@ -18,6 +19,7 @@ export default function RootLayout({
       <body
         className={`${inter.className} leading-relaxed antialiased selection:bg-emerald-400 selection:text-emerald-900`}
       >
+        <GradientBackground />
         {children}
         <Analytics />
         <SpeedInsights />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -15,7 +15,7 @@ import { Suspense } from "react";
 
 export default async function Home() {
   return (
-    <div className="bg-background mx-auto min-h-screen max-w-screen-xl px-6 py-12 font-sans md:px-12 md:py-20 lg:px-24 lg:py-0">
+    <div className="mx-auto min-h-screen max-w-screen-xl px-6 py-12 font-sans md:px-12 md:py-20 lg:px-24 lg:py-0">
       <div className="lg:flex lg:justify-between lg:gap-4">
         {/* Left Column */}
         <div className="lg:sticky lg:top-0 lg:flex lg:h-screen lg:w-1/2 lg:flex-col lg:justify-between lg:py-24">

--- a/src/components/GradientBackground.tsx
+++ b/src/components/GradientBackground.tsx
@@ -1,0 +1,30 @@
+// Decorative grainy-gradient backdrop: soft emerald blobs slowly drifting over
+// the near-black base, finished with an SVG film-grain overlay. Pure CSS, so
+// this stays a Server Component and ships no JS. Styles live in
+// styles/globals.css (search "grainy-gradient background").
+//
+// `intensity` sets how strongly the green reads through. You can also flip the
+// rendered `data-intensity` between "whisper" and "noticeable" live in devtools
+// to compare the two presets without a rebuild.
+
+type Intensity = "whisper" | "noticeable";
+
+export default function GradientBackground({
+  intensity = "noticeable",
+}: {
+  intensity?: Intensity;
+}) {
+  return (
+    <div
+      aria-hidden="true"
+      data-intensity={intensity}
+      className="grain-bg pointer-events-none fixed inset-0 -z-10 overflow-hidden"
+    >
+      <div className="grain-blob grain-blob--1" />
+      <div className="grain-blob grain-blob--2" />
+      <div className="grain-blob grain-blob--3" />
+      <div className="grain-blob grain-blob--4" />
+      <div className="grain-overlay" />
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -110,6 +110,9 @@ html {
   /* default preset = noticeable */
   --blob-alpha: 0.18;
   --grain-opacity: 0.16;
+  /* Blob travel speed. 1 = base · 1.5 = current · 2-3 = frenetic · 0.5 = calm.
+     Scrub this live in devtools (select .grain-bg) to find your pace. */
+  --blob-speed: 1.5;
 }
 .grain-bg[data-intensity="whisper"] {
   --blob-alpha: 0.1;
@@ -126,7 +129,7 @@ html {
   will-change: transform;
 }
 
-/* emerald-500 — upper left */
+/* emerald-500 — starts upper left, sweeps the top + right */
 .grain-blob--1 {
   width: 52vw;
   height: 52vw;
@@ -137,10 +140,10 @@ html {
     rgb(16 185 129 / var(--blob-alpha)) 0%,
     transparent 100%
   );
-  animation: grain-drift-1 34s ease-in-out infinite alternate;
+  animation: grain-drift-1 calc(26s / var(--blob-speed)) ease-in-out infinite;
 }
 
-/* emerald-400 — right, lower */
+/* emerald-400 — starts right, drifts across to the left */
 .grain-blob--2 {
   width: 40vw;
   height: 40vw;
@@ -151,10 +154,10 @@ html {
     rgb(52 211 153 / var(--blob-alpha)) 0%,
     transparent 100%
   );
-  animation: grain-drift-2 42s ease-in-out -8s infinite alternate;
+  animation: grain-drift-2 calc(22s / var(--blob-speed)) ease-in-out -8s infinite;
 }
 
-/* brand emerald (#6ee7b7) — bottom, slightly right */
+/* brand emerald (#6ee7b7) — rises from the bottom up the middle */
 .grain-blob--3 {
   width: 48vw;
   height: 48vw;
@@ -165,10 +168,10 @@ html {
     rgb(110 231 183 / var(--blob-alpha)) 0%,
     transparent 100%
   );
-  animation: grain-drift-3 30s ease-in-out -4s infinite alternate;
+  animation: grain-drift-3 calc(30s / var(--blob-speed)) ease-in-out -4s infinite;
 }
 
-/* emerald-600 — left, upper-mid */
+/* emerald-600 — starts lower left, climbs up the right */
 .grain-blob--4 {
   width: 36vw;
   height: 36vw;
@@ -179,7 +182,7 @@ html {
     rgb(5 150 105 / var(--blob-alpha)) 0%,
     transparent 100%
   );
-  animation: grain-drift-4 38s ease-in-out -12s infinite alternate;
+  animation: grain-drift-4 calc(24s / var(--blob-speed)) ease-in-out -12s infinite;
 }
 
 .grain-overlay {
@@ -190,50 +193,76 @@ html {
   background-size: 220px 220px;
 }
 
-/* Drift + turn + stretch. Non-uniform scale makes each soft circle breathe
-   into shifting ellipses; the 3 stops + alternate avoid an obvious loop. */
+/* Lava-lamp roaming: each blob travels a large closed circuit across the
+   screen (0% == 100%, so it loops seamlessly with `infinite` — no retrace),
+   turning and stretching via rotate + non-uniform scale as it goes. Distinct
+   circuits + negative delays keep them from clumping. */
 @keyframes grain-drift-1 {
   0% {
     transform: translate3d(0, 0, 0) rotate(0deg) scale(1, 1);
   }
+  25% {
+    transform: translate3d(48vw, 16vw, 0) rotate(10deg) scale(1.1, 0.92);
+  }
   50% {
-    transform: translate3d(3vw, 4vw, 0) rotate(8deg) scale(1.15, 0.9);
+    transform: translate3d(68vw, 52vw, 0) rotate(-8deg) scale(0.94, 1.16);
+  }
+  75% {
+    transform: translate3d(22vw, 40vw, 0) rotate(12deg) scale(1.14, 0.9);
   }
   100% {
-    transform: translate3d(5vw, 2vw, 0) rotate(-6deg) scale(0.95, 1.12);
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1, 1);
   }
 }
 @keyframes grain-drift-2 {
   0% {
     transform: translate3d(0, 0, 0) rotate(0deg) scale(1.05, 0.95);
   }
+  25% {
+    transform: translate3d(-44vw, 26vw, 0) rotate(-9deg) scale(0.92, 1.14);
+  }
   50% {
-    transform: translate3d(-4vw, 3vw, 0) rotate(-9deg) scale(0.9, 1.15);
+    transform: translate3d(-64vw, -8vw, 0) rotate(8deg) scale(1.12, 0.94);
+  }
+  75% {
+    transform: translate3d(-24vw, -26vw, 0) rotate(-11deg) scale(0.96, 1.1);
   }
   100% {
-    transform: translate3d(-6vw, 5vw, 0) rotate(6deg) scale(1.1, 0.95);
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1.05, 0.95);
   }
 }
 @keyframes grain-drift-3 {
   0% {
     transform: translate3d(0, 0, 0) rotate(0deg) scale(1, 1);
   }
+  25% {
+    transform: translate3d(-30vw, -34vw, 0) rotate(9deg) scale(1.12, 0.93);
+  }
   50% {
-    transform: translate3d(-3vw, -4vw, 0) rotate(7deg) scale(1.12, 0.92);
+    transform: translate3d(-54vw, -56vw, 0) rotate(-7deg) scale(0.95, 1.15);
+  }
+  75% {
+    transform: translate3d(-16vw, -22vw, 0) rotate(11deg) scale(1.1, 0.92);
   }
   100% {
-    transform: translate3d(-5vw, -2vw, 0) rotate(-8deg) scale(0.94, 1.1);
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1, 1);
   }
 }
 @keyframes grain-drift-4 {
   0% {
     transform: translate3d(0, 0, 0) rotate(0deg) scale(1.05, 1);
   }
+  25% {
+    transform: translate3d(40vw, -28vw, 0) rotate(-8deg) scale(0.93, 1.13);
+  }
   50% {
-    transform: translate3d(4vw, -3vw, 0) rotate(-7deg) scale(0.92, 1.14);
+    transform: translate3d(64vw, -54vw, 0) rotate(10deg) scale(1.14, 0.92);
+  }
+  75% {
+    transform: translate3d(26vw, -20vw, 0) rotate(-12deg) scale(0.96, 1.1);
   }
   100% {
-    transform: translate3d(6vw, -5vw, 0) rotate(9deg) scale(1.1, 0.93);
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1.05, 1);
   }
 }
 

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -96,3 +96,151 @@ html {
 }*/
 
 /* styles/globals.css or any of your global CSS files */
+
+/* ============================================================
+   Grainy-gradient background  (see components/GradientBackground.tsx)
+   Soft emerald patches drift, turn, and stretch over the near-black base;
+   an SVG film-grain overlay sits on top. Each patch is a radial gradient
+   that fades to transparent, so the green stays concentrated (~a third of
+   each blob) and the canvas reads mostly black. Animation is transform-only
+   (translate + rotate + non-uniform scale) → stays on the GPU.
+   Flip data-intensity "whisper" | "noticeable" live in devtools to compare.
+   ============================================================ */
+.grain-bg {
+  /* default preset = noticeable */
+  --blob-alpha: 0.18;
+  --grain-opacity: 0.16;
+}
+.grain-bg[data-intensity="whisper"] {
+  --blob-alpha: 0.1;
+  --grain-opacity: 0.12;
+}
+.grain-bg[data-intensity="noticeable"] {
+  --blob-alpha: 0.18;
+  --grain-opacity: 0.16;
+}
+
+.grain-blob {
+  position: absolute;
+  filter: blur(70px);
+  will-change: transform;
+}
+
+/* emerald-500 — upper left */
+.grain-blob--1 {
+  width: 52vw;
+  height: 52vw;
+  top: -12vw;
+  left: -10vw;
+  background: radial-gradient(
+    circle closest-side,
+    rgb(16 185 129 / var(--blob-alpha)) 0%,
+    transparent 100%
+  );
+  animation: grain-drift-1 34s ease-in-out infinite alternate;
+}
+
+/* emerald-400 — right, lower */
+.grain-blob--2 {
+  width: 40vw;
+  height: 40vw;
+  top: 8vw;
+  right: -12vw;
+  background: radial-gradient(
+    circle closest-side,
+    rgb(52 211 153 / var(--blob-alpha)) 0%,
+    transparent 100%
+  );
+  animation: grain-drift-2 42s ease-in-out -8s infinite alternate;
+}
+
+/* brand emerald (#6ee7b7) — bottom, slightly right */
+.grain-blob--3 {
+  width: 48vw;
+  height: 48vw;
+  right: 2vw;
+  bottom: -14vw;
+  background: radial-gradient(
+    circle closest-side,
+    rgb(110 231 183 / var(--blob-alpha)) 0%,
+    transparent 100%
+  );
+  animation: grain-drift-3 30s ease-in-out -4s infinite alternate;
+}
+
+/* emerald-600 — left, upper-mid */
+.grain-blob--4 {
+  width: 36vw;
+  height: 36vw;
+  bottom: 6vw;
+  left: -12vw;
+  background: radial-gradient(
+    circle closest-side,
+    rgb(5 150 105 / var(--blob-alpha)) 0%,
+    transparent 100%
+  );
+  animation: grain-drift-4 38s ease-in-out -12s infinite alternate;
+}
+
+.grain-overlay {
+  position: absolute;
+  inset: 0;
+  opacity: var(--grain-opacity);
+  background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='grain'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.75' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23grain)'/%3E%3C/svg%3E");
+  background-size: 220px 220px;
+}
+
+/* Drift + turn + stretch. Non-uniform scale makes each soft circle breathe
+   into shifting ellipses; the 3 stops + alternate avoid an obvious loop. */
+@keyframes grain-drift-1 {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1, 1);
+  }
+  50% {
+    transform: translate3d(3vw, 4vw, 0) rotate(8deg) scale(1.15, 0.9);
+  }
+  100% {
+    transform: translate3d(5vw, 2vw, 0) rotate(-6deg) scale(0.95, 1.12);
+  }
+}
+@keyframes grain-drift-2 {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1.05, 0.95);
+  }
+  50% {
+    transform: translate3d(-4vw, 3vw, 0) rotate(-9deg) scale(0.9, 1.15);
+  }
+  100% {
+    transform: translate3d(-6vw, 5vw, 0) rotate(6deg) scale(1.1, 0.95);
+  }
+}
+@keyframes grain-drift-3 {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1, 1);
+  }
+  50% {
+    transform: translate3d(-3vw, -4vw, 0) rotate(7deg) scale(1.12, 0.92);
+  }
+  100% {
+    transform: translate3d(-5vw, -2vw, 0) rotate(-8deg) scale(0.94, 1.1);
+  }
+}
+@keyframes grain-drift-4 {
+  0% {
+    transform: translate3d(0, 0, 0) rotate(0deg) scale(1.05, 1);
+  }
+  50% {
+    transform: translate3d(4vw, -3vw, 0) rotate(-7deg) scale(0.92, 1.14);
+  }
+  100% {
+    transform: translate3d(6vw, -5vw, 0) rotate(9deg) scale(1.1, 0.93);
+  }
+}
+
+/* Respect users who ask for less motion: freeze the drift; each patch rests
+   at its base position/shape (the 0% keyframe). */
+@media (prefers-reduced-motion: reduce) {
+  .grain-blob {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## What
Adds a fixed, decorative **grainy gradient background** site-wide: soft emerald radial blobs that slowly drift, rotate, and scale over the near-black base, with an SVG fractal-noise grain overlay on top.

## Notes
- Pure CSS, Server Component (no JS shipped); honors `prefers-reduced-motion`.
- Intensity toggleable via `data-intensity` (default `noticeable`); flip to `whisper` for subtler.
- Background-only: no content/layout/logic changes. The one structural edit makes the page.tsx wrapper transparent so the layer shows through.

**Opened to preview the effect on a Vercel deployment — not necessarily to merge yet.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)